### PR TITLE
bug | finish loading loady would go to the left.

### DIFF
--- a/Loady/Classes/LoadyButton/Loady.swift
+++ b/Loady/Classes/LoadyButton/Loady.swift
@@ -41,7 +41,7 @@ open class LoadyButton : UIButton, Loadiable {
 		
 		self.bounds = CGRect(x:0,y: 0,width: cached.frame.size.width,height: cached.frame.size.height)
 		self.layer.cornerRadius = cached.layer.cornerRadius
-		self.frame.origin.x = 0
+//		self.frame.origin.x = 0
 		self.backgroundColor = cached.backgroundColor
 		self.transform = .identity
 		self.layoutIfNeeded()


### PR DESCRIPTION
Finish loading, the loady button would go to the left side in iOS11.4 running in iPhone 6 model.